### PR TITLE
Restrict the writeLogsPolicy

### DIFF
--- a/cfn/templates/lambda.yaml
+++ b/cfn/templates/lambda.yaml
@@ -28,13 +28,24 @@ Resources:
       PolicyDocument: 
         Version: "2012-10-17"
         Statement:
-          -
-            Effect: "Allow"
+          - Effect: "Allow"
             Action: 
-              - "s3:Get*"
-              - "s3:List*"
-              - "s3:PutObject"
-            Resource: "*" 
+              - s3:GetObject
+              - s3:PutObject
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:aws:s3:::"
+                  - Ref: s3bucket
+                  - "/*"
+          - Effect: "Allow"
+            Action:
+              - s3:ListBucket
+            Resource:
+              Fn::Join:
+                - ""
+                - - "arn:aws:s3:::"
+                  - Ref: s3bucket
       Roles:
         - Ref: lambdaRole
   readLogsPolicy:


### PR DESCRIPTION
1. Split permissions related to 'Bucket Operations' and 'Object Operations'
2. Specify the Bucket in Resource.
3. Remove the wildcard from the Action.