### PR TITLE
Update the bucket operation policy

### DIFF
--- a/cfn/templates/lambda.yaml
+++ b/cfn/templates/lambda.yaml
@@ -40,12 +40,9 @@ Resources:
                   - "/*"
           - Effect: "Allow"
             Action:
-              - s3:ListBucket
-            Resource:
-              Fn::Join:
-                - ""
-                - - "arn:aws:s3:::"
-                  - Ref: s3bucket
+            - s3:ListBucket
+            Resource: 
+            - arn:aws:s3:::*
       Roles:
         - Ref: lambdaRole
   readLogsPolicy:


### PR DESCRIPTION
Permissions Related to Bucket Operations does not specify the bucket
https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html